### PR TITLE
Открыть currentState

### DIFF
--- a/lib/src/Bloc.dart
+++ b/lib/src/Bloc.dart
@@ -5,10 +5,10 @@ import 'Reducer.dart';
 import 'State.dart';
 
 abstract class Bloc<S extends State, A extends Action, R extends Reducer> {
-  final _stateController = StreamController<State>.broadcast();
-  final _actionsController = StreamController<Action>();
+  final _stateController = StreamController<S>.broadcast();
+  final _actionsController = StreamController<A>();
 
-  var _currentState;
+  S currentState;
 
   Stream<State> get state => _stateController.stream;
   Sink<Action> get action => _actionsController.sink;
@@ -16,19 +16,20 @@ abstract class Bloc<S extends State, A extends Action, R extends Reducer> {
 
   final Map<Type, R> _reducers;
 
-  Bloc(this._reducers, this._currentState) {
+  Bloc(this._reducers, S initialState) {
+    currentState = initialState;
     _actionsController.stream.listen(handleAction);
     _stateListener = (state) {
       _stateController.sink.add(state);
-      _currentState = state;
+      currentState = state;
     };
 
-    _stateController.add(_currentState);
+    _stateController.add(currentState);
   }
 
-  void handleAction(Action action) async {
+  void handleAction(A action) async {
     _reducers[action.runtimeType]
-        ?.call(_currentState, action)
+        ?.call(currentState, action)
         ?.listen(_stateListener);
   }
 
@@ -37,7 +38,7 @@ abstract class Bloc<S extends State, A extends Action, R extends Reducer> {
     _actionsController.close();
   }
 
-  void add(Action action) {
+  void add(A action) {
     _actionsController.sink.add(action);
   }
 }

--- a/lib/src/Bloc.dart
+++ b/lib/src/Bloc.dart
@@ -8,28 +8,29 @@ abstract class Bloc<S extends State, A extends Action, R extends Reducer> {
   final _stateController = StreamController<S>.broadcast();
   final _actionsController = StreamController<A>();
 
-  S currentState;
+  S _currentState;
 
   Stream<State> get state => _stateController.stream;
+  S get currentState => _currentState;
   Sink<Action> get action => _actionsController.sink;
   StateListener _stateListener;
 
   final Map<Type, R> _reducers;
 
   Bloc(this._reducers, S initialState) {
-    currentState = initialState;
+    _currentState = initialState;
     _actionsController.stream.listen(handleAction);
     _stateListener = (state) {
       _stateController.sink.add(state);
-      currentState = state;
+      _currentState = state;
     };
 
-    _stateController.add(currentState);
+    _stateController.add(_currentState);
   }
 
   void handleAction(A action) async {
     _reducers[action.runtimeType]
-        ?.call(currentState, action)
+        ?.call(_currentState, action)
         ?.listen(_stateListener);
   }
 


### PR DESCRIPTION
Чтобы **StreamBuilder** мог подключаться к блоку и сразу отображать актуальное состояние без отправки **action**, надо открыть наружу пропертю **currentState** и передавать её как **initialData** в конструктор **StreamBuilder**.

Пользуясь случаем поправил типы данных, которые должны браться из Generic'ов, чтобы нельзя было передавать чужие действия х)